### PR TITLE
remove duplicate lombok dependency

### DIFF
--- a/1-bootstrap/guestbook-frontend/pom.xml
+++ b/1-bootstrap/guestbook-frontend/pom.xml
@@ -50,11 +50,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
This avoids the following warning when building:

> [WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.example:frontend:jar:0.0.1-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.projectlombok:lombok:jar -> duplicate declaration of version (?) @ line 52, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 